### PR TITLE
Disable use with do syntax, for now.

### DIFF
--- a/src/Underscores.jl
+++ b/src/Underscores.jl
@@ -82,6 +82,8 @@ function lower_underscores(ex)
             # Broadcast calls treated as normal calls for underscore lowering
             return replace__(Expr(ex.head, replace_(ex.args[1]),
                                   Expr(:tuple, map(replace_, ex.args[2].args)...)))
+        elseif ex.head == :do
+            error("@_ expansion for `do` syntax is reserved")
         else
             # For other syntax, replace _ in args individually and __ over the
             # entire expression.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,5 +119,11 @@ end
     @test lower(:((f(_), g(_))))  == cleanup!(:(((_1,)->f(_1)), ((_1,)->g(_1))))
     @test lower(:([__])) == cleanup!(:((__1,)->[__1]))
     @test lower(:(__.x)) == cleanup!(:((__1,)->__1.x))
+
+    # do syntax is disabled for now because desired behaviour is not entirely
+    # clear. See #4
+    @test_throws ErrorException lower(:(f() do
+                                            body
+                                        end))
 end
 


### PR DESCRIPTION
This way version 2 can be released immediately and we'll be able to
consider further what to do about `do` syntax.

Possibly the right thing for this is #4, though it's not entirely clear that this is consistent.