### PR TITLE
Recurse _ to bypass square brackets, and usually-infix operators

### DIFF
--- a/src/Underscores.jl
+++ b/src/Underscores.jl
@@ -106,7 +106,7 @@ and *pass them along* to `func`.
 
 The detailed rules are:
 1. Uses of the placeholder `_` expand to the single argument of an anonymous
-   function which is passed to the outermost parenthesized expression.
+   function which is passed to the outermost ordinary function call.
 2. Numbered placeholders `_1,_2,...` (or `_₁,_₂,...`) may be used if you need
    more than one argument. Numbers indicate position in the argument list.
 3. The double underscore placeholder `__` (and numbered versions `__1,__2,...`)
@@ -126,18 +126,6 @@ These rules imply the following equivalences
 | `@_ data \\|> map(_.f,__)` | (1,3,4) | `data \\|> (d->map(x->x.f,d))` |
 
 # Extended help
-
-The scope of `_` is described in rule 1 as passing a function to the outermost
-"parenthesized expression", which includes ordinary function calls like `func`
-above. However, it excludes indexing: In `map(_^2,__)[3]`, it is `map` which
-receives an anonymous function, as this happens before the indexing is lowered
-to `getindex(...,3)`.
-
-The scope of `__` is unaffected by these concerns.
-
-| Expression                     | Meaning                            |
-|:------------------------------ |:---------------------------------- |
-| `@_ data \\|> map(_[2],__)[3]` | `data \\|> (d->map(x->x[2],d)[3])` |
 
 ## Examples
 
@@ -178,6 +166,20 @@ julia> @_ table |>
  2
  3
 ```
+
+## Extraordinary functions
+
+The scope of `_` as described in rule 1 depends on "ordinary" function call.
+This excludes the following operations:
+
+* Square brackets: In `map(_^2,__)[3]`, it is `map` which receives an anonymous
+  function, as this happens before the indexing is lowered to `getindex(...,3)`.
+
+The scope of `__` is unaffected by these concerns.
+
+| Expression                       | Meaning                            |
+|:-------------------------------- |:---------------------------------- |
+| `@_ data \\|> map(_[2],__)[3]`   | `data \\|> (d->map(x->x[2],d)[3])` |
 """
 macro _(ex)
     esc(lower_underscores(ex))

--- a/src/Underscores.jl
+++ b/src/Underscores.jl
@@ -62,12 +62,6 @@ end
 replace_(ex)  = add_closures(ex, "_", r"^_([0-9]*|[₀-₉]*)$")
 replace__(ex) = add_closures(ex, "__", r"^__([0-9]*|[₀-₉]*)$")
 
-# In principle this can be extended locally by a package for use within the
-# package and for prototyping purposes. However note that this will interact
-# badly with precompilation. (If it makes sense we could fix this per-package
-# by storing a per-module _pipeline_ops in the module using @_.)
-const _pipeline_ops = [:|>, :<|, :∘]
-
 const _square_bracket_ops = [:comprehension, :typed_comprehension, :generator,
                              :ref, :vcat, :typed_vcat, :hcat, :typed_hcat, :row]
 
@@ -100,7 +94,13 @@ function lower_inner(ex)
     end
 end
 
-function lower_underscores(ex, replace__=replace__)
+# In principle this can be extended locally by a package for use within the
+# package and for prototyping purposes. However note that this will interact
+# badly with precompilation. (If it makes sense we could fix this per-package
+# by storing a per-module _pipeline_ops in the module using @_.)
+const _pipeline_ops = [:|>, :<|, :∘]
+
+function lower_underscores(ex)
     if ex isa Expr
         if isquoted(ex)
             return ex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,11 @@ end
     @test lower(:(f.(__)))  == cleanup!(:((__1,)->f.(__1)))
     @test lower(:((_).(x)))  == cleanup!(:(((_1,)->_1).(x)))
 
+    # Indexing
+    @test lower(:(f(_)[2])) == cleanup!(:(f((_1,)->_1)[2]))
+    @test lower(:(f(g(_[3]),h)[4])) == cleanup!(:(f((_1,)->g(_1[3]),h)[4]))
+    @test lower(:(f(__)[5])) == cleanup!(:((__1,)->f(__1)[5]))
+
     # Random sample of other syntax
     @test lower(:([_]))  == cleanup!(:([(_1,)->_1]))
     @test lower(:((f(_), g(_))))  == cleanup!(:(((_1,)->f(_1)), ((_1,)->g(_1))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ using Test
     # Use with indexing
     @test data[1] == @_ filter(startswith(_.x, "a"), data)[end]
     @test data[2:3] == @_ filter(_.y >= 2, data)[1:2]
+    @test data[2] == @_ data[findfirst(_.y >= 2, data)]
 
     # Operators
     @test -2 == @_ -findfirst(_.x == "b", data)
@@ -54,8 +55,17 @@ using Test
 
     @test [1] == @_(Map(_.y) ∘ Filter(startswith(_.x, "a")))(data)
 
+    # Getproperty
+    @test "a" == @_ data |> __[1].x
+    @test "b" == @_ (x="a", y=(z="b", t="c")) |> __.y.z
+    @test "c" == @_ (x="a", y=(z="b", t="c")) |> __.y[end]
+    @test -3 == @_ [1+2im,3,4+5im] |> sum(_^2, __).re
+
     # Interpolation
     @test ["1","a","2.0"] == @_ map("$_", [1,"a",2.0])
+
+    # Broadcasting
+    @_ [[1],[2],[3]] == data |> filter.(_ isa Int, collect.(__))
 
     # Comprehensions
     @test [[],[],[3]] == @_ [[1], [1,2], [1,2,3]] |>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,19 @@ using Test
                     Map(_.y)
 
     @test [1] == @_(Map(_.y) ∘ Filter(startswith(_.x, "a")))(data)
+
+    # Interpolation
+    @test ["1","a","2.0"] == @_ map("$_", [1,"a",2.0])
+
+    # Comprehensions
+    @test [[],[],[3]] == @_ [[1], [1,2], [1,2,3]] |>
+                                [filter(_>2, x) for x in __]
+    @test fill(:y,3) == @_ data |>
+                        Symbol[findfirst(_ isa Int, x) for x in __]
+
+    # Matrix construction
+    @test 4*ones(2,2) == @_ ones(4) |> [ sum(__)      sum(_^2, __)
+                                         sum(_^3, __) sum(_^4, __) ]
 end
 
 @testset "Underscores lowering" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,11 @@ using Test
     @test data[1] == @_ filter(startswith(_.x, "a"), data)[end]
     @test data[2:3] == @_ filter(_.y >= 2, data)[1:2]
 
+    # Operators
+    @test -2 == @_ -findfirst(_.x == "b", data)
+    @test [14] == @_ [1 2 3] * map(_.y, data)
+    @test (1:3)./3 == @_ data |> map(_.y, __) ./ length(__)
+
     # Multiple args
     @test [0,0] == @_ map(_-_, [1,2])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,10 @@ using Test
     @test data[1:1] == @_ filter(startswith(_.x, "a"), data)
     @test data[2:3] == @_ filter(_.y >= 2, data)
 
+    # Use with indexing
+    @test data[1] == @_ filter(startswith(_.x, "a"), data)[end]
+    @test data[2:3] == @_ filter(_.y >= 2, data)[1:2]
+
     # Multiple args
     @test [0,0] == @_ map(_-_, [1,2])
 
@@ -30,6 +34,10 @@ using Test
                      filter(startswith(_.x, "a"), __))(data)
 
     @test [0,0,0] == @_ data |> map(_1.y + _2, __, [-1,-2,-3])
+
+    @test 3 == @_ [[1], [1,2], [1,2,3]] |>
+                                map(_[_[end]], __) |>
+                                __[end]
 
     # Use with piping and lazy versions of map and filter
     Filter(f) = x->filter(f,x)


### PR DESCRIPTION
Ref #8. 

There may be weird edge cases I've missed, for instance what happens if `_` appears inside `[ ]`?