### PR TITLE
Interpolate `do` syntax closures into single _

### DIFF
--- a/src/Underscores.jl
+++ b/src/Underscores.jl
@@ -123,11 +123,11 @@ function lower_underscores(ex)
                     end
                 end
                 call = lower_inner(call)
-                return :(let $do_func = $(ex.args[2])
-                             $call
-                         end)
+                return replace__(:(let $do_func = $(ex.args[2])
+                                       $call
+                                   end))
             else
-                return Expr(:do, lower_inner(call), ex.args[2:end]...)
+                return replace__(Expr(:do, lower_inner(call), ex.args[2:end]...))
             end
         else
             # For other syntax, replace __ over the entire expression

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,12 @@ using Test
     @test [1,4] == @_ map([1,2]) do x
         x^2
     end
+    # Use with __. Yikes :-/
+    @test 14 == @_ function (x)
+        x^2
+    end |> mapreduce(__, _, [1,2,3]) do x,y
+        x+y
+    end
 
     # Use with piping and __
     @test [1] == @_ data |>
@@ -199,5 +205,7 @@ end
                    end))
     # do without _'s
     @test lower(:(f() do ; body end)) == cleanup!(:(f() do ; body end))
+    # do with __, without _'s
+    @test lower(:(f(__) do ; body end)) == cleanup!(:((__1,)->f(__1) do ; body end))
 end
 


### PR DESCRIPTION
This allows a single `_` to be treated as the slot into which the closure created by do syntax is inserted.

It's somewhat overloaded in that `@_ map(_, xs)` normally means the `_` is the identity, while `@_ map(_, xs) do ...` would mean the same as normal do syntax without the `_`, but conceptually we're marking a "slot of map" to receive a closure so it could be acceptably consistent.

Also, it seems likely to be extremely convenient.

A more realistic example would be a function which takes multiple functions as arguments (eg `mapreduce(f, _, xs) do ...`) allowing the second argument to be given with the `do` block.

CC @tkf @masonprotter and anyone else interested — thoughts? Does this seem acceptably consistent?

Closes #4 by replacing it